### PR TITLE
Added setup.py for prjuray Python code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ build/
 env/
 __pycache__
 *.py[co]
-
+*.egg-info

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pytest
 virtualenv
 yapf==0.24.0
-intervaltree
-simplejson
+-e ./

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[metadata]
+license_files = COPYING
+
+[bdist_wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,18 @@
+import setuptools
+
+setuptools.setup(
+    name="prjuray",
+    version="0.0.1",
+    author="SymbiFlow Authors",
+    author_email="symbiflow@lists.librecores.org",
+    description="Project U-Ray database access code",
+    long_description="",
+    url="https://github.com/SymbiFlow/prjuray-tools",
+    packages=setuptools.find_packages(),
+    install_requires=['intervaltree', 'simplejson'],
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: ISC License",
+        "Operating System :: OS Independent",
+    ],
+)

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,14 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020  The Project U-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+
 import setuptools
 
 setuptools.setup(


### PR DESCRIPTION
This PR adds `setup.py` to prjuray db-access code so it can be installed as a Python module eg. in a venv.